### PR TITLE
Locks activesupport to >= 5.0 and json >= 2.0.3

### DIFF
--- a/newline_hw.gemspec
+++ b/newline_hw.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.2.2'
   spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "json", ">= 2.0.3"
   spec.add_dependency "thor", "~> 0.19.1"

--- a/newline_hw.gemspec
+++ b/newline_hw.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "activesupport"
-  spec.add_dependency "json"
+  spec.add_dependency "activesupport", ">= 5.0"
+  spec.add_dependency "json", ">= 2.0.3"
   spec.add_dependency "thor", "~> 0.19.1"
   spec.add_dependency "newline_cli", ">= 0.2.5"
 


### PR DESCRIPTION
To hopefully avoid errors non-Rubyists are running into as far as versions of activesupport and json conflicting.